### PR TITLE
Revert PR 9 changes

### DIFF
--- a/Example Projects/dotNetCoreExample/Examples/Basic/BasicSendWithRetry.cs
+++ b/Example Projects/dotNetCoreExample/Examples/Basic/BasicSendWithRetry.cs
@@ -14,7 +14,6 @@ namespace dotNetCoreExample.Examples.Basic
             var client = new SocketLabsClient(ExampleConfig.ServerId, ExampleConfig.ApiKey, proxy)
             {
                 EndpointUrl = ExampleConfig.TargetApi,
-                RequestTimeout = 120,
                 NumberOfRetries = 3
             };
 

--- a/src/SocketLabs/InjectionApi/Core/RetryHandler.cs
+++ b/src/SocketLabs/InjectionApi/Core/RetryHandler.cs
@@ -53,7 +53,7 @@ namespace SocketLabs.InjectionApi.Core
                 {
                     var response = await HttpClient.PostAsync(EndpointUrl, content, cancellationToken)
                         .ConfigureAwait(false);
-
+                    
                     if (ErrorStatusCodes.Contains(response.StatusCode))
                         throw new HttpRequestException(
                             $"HttpStatusCode: '{response.StatusCode}'. Response contains server error.");

--- a/src/SocketLabs/InjectionApi/SocketLabsClient.cs
+++ b/src/SocketLabs/InjectionApi/SocketLabsClient.cs
@@ -43,12 +43,7 @@ namespace SocketLabs.InjectionApi
         /// The SocketLabs Injection API endpoint Url
         /// </summary>
         public string EndpointUrl { get; set; } = "https://inject.socketlabs.com/api/v1/email";
-
-        /// <summary>
-        /// A timeout period for the Injection API request (in Seconds). Default: 120s
-        /// </summary>
-        public int RequestTimeout { get; set; } = 120;
-
+        
         /// <summary>
         /// RetrySettings object to define retry setting for the Injection API request.
         /// </summary>
@@ -237,9 +232,7 @@ namespace SocketLabs.InjectionApi
             var factory = new InjectionRequestFactory(_serverId, _apiKey);
             var injectionRequest = factory.GenerateRequest(message);
             var json = injectionRequest.GetAsJson();
-
-            _httpClient.Timeout = TimeSpan.FromSeconds(RequestTimeout);
-
+            
             var retryHandler = new RetryHandler(_httpClient, EndpointUrl, new RetrySettings(NumberOfRetries));
             var httpResponse = await retryHandler.SendAsync(json, cancellationToken);
 
@@ -292,9 +285,7 @@ namespace SocketLabs.InjectionApi
             var factory = new InjectionRequestFactory(_serverId, _apiKey);
             var injectionRequest = factory.GenerateRequest(message);
             var json = injectionRequest.GetAsJson();
-
-            _httpClient.Timeout = TimeSpan.FromSeconds(RequestTimeout);
-
+            
             var retryHandler = new RetryHandler(_httpClient, EndpointUrl, new RetrySettings(NumberOfRetries));
             var httpResponse = await retryHandler.SendAsync(json, cancellationToken);
 


### PR DESCRIPTION
This PR is to revert the changes made in https://github.com/socketlabs/socketlabs-csharp/pull/9

If a timeout is required on the HttpClient it should be set on an HttpClient instance passed in via the `new SocketLabsClient(x, y, httpClient)` ctor call.

Why?

A HttpClient timeout property cannot be modified after using it.

https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.timeout?view=net-5.0

As the timeout is set during the SendAsync call, it will throw an error next time this code runs unless a new HttpClient instance is created for each send call. This has broken HttpClient reuse.


> The same timeout will apply for all requests using this HttpClient instance. You may also set different timeouts for individual requests using a CancellationTokenSource on a task. Note that only the shorter of the two timeouts will apply.


Please note the above - from the MSDN docs. If per-request timeouts are required, then CTS should be used on the task, causing the task to cancel.

If SendAsync is called for a second time on the same SocketLabsClient the following will be thrown:

```
System.InvalidOperationException: This instance has already started one or more requests. Properties can only be modified before sending the first request.
   at System.Net.Http.HttpClient.CheckDisposedOrStarted()
   at System.Net.Http.HttpClient.set_Timeout(TimeSpan value)
   at SocketLabs.InjectionApi.SocketLabsClient.SendAsync(IBasicMessage message, CancellationToken cancellationToken)
```

I recommend reverting as a user can simply create their own HttpClient with their use case specific RequestTimeout, and then pass that configured client in via the constructor which allows this.

However, if per-request timeouts were required, and the SocketLabsClient wanted to support that, you could consider using CTS on the Task to cancel in-flight requests, however, this change is out of scope of this fix. I would also argue that the caller should configure this as required.
